### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can now view your website in French.
 
 #### Download
 
-Via pip ![latest version](https://pypip.in/v/django-transadmin/badge.png)
+Via pip ![latest version](https://img.shields.io/pypi/v/django-transadmin.svg)
 
 ```bash
 pip install django-transadmin


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-transadmin))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-transadmin`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.